### PR TITLE
Improve close-connection + prepare-upload rejection behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,6 @@ The application implements the [Tella Nearby Sharing protocol](https://github.co
 - `POST /api/v1/register` - Device registration with PIN authentication
 - `POST /api/v1/prepare-upload` - Prepare file transfer session
 - `PUT /api/v1/upload` - File upload with binary data
-
-**Endpoints not fully implemented as of 2026-02-12:**
-
 * `POST /api/v1/close-connection`
 
 ## Platform-Specific Notes

--- a/backend/app/app.go
+++ b/backend/app/app.go
@@ -42,6 +42,11 @@ func (a *App) IsFirstTimeSetup() bool {
 	return a.authService.IsFirstTimeSetup()
 }
 
+
+func (a *App) IsDevelopment() bool {
+	return devlog.IsDevelop()
+}
+
 // TODO cblgh(2026-02-12): authService.CreatePassword currently unlocks the database. should it?
 func (a *App) CreatePassword(password string) error {
 	err := a.authService.CreatePassword(password)

--- a/backend/core/modules/server/service.go
+++ b/backend/core/modules/server/service.go
@@ -148,16 +148,9 @@ func (s *service) Start(port int) error {
 
 	mux := http.NewServeMux()
 
-	// TODO cblgh(2026-02-16): pass something (serverErrors? another channel?) to transfer's handler so that
-	// close-connection can terminate the server
 	transferHandler := transfer.NewHandler(s.transferService, s.fileService, s.defaultFolderID, s.nonceManager)
 
 	// TODO (2026-02-19): dhekra / iOS closes the server when the transfer is explicitly stopped
-	// TODO cblgh(2026-02-16): if using channel for close-connection then make sure, for all other paths, to drain <-done so that we don't have a goroutine leak
-	// go func() {
-	// 	<-done
-	// 	s.Stop(context.TODO)
-	// }()
 
 	handler := NewHandler(mux, s.registrationHandler, transferHandler)
 	handler.SetupRoutes()

--- a/backend/core/modules/transfer/handler.go
+++ b/backend/core/modules/transfer/handler.go
@@ -35,6 +35,7 @@ type closeInfo struct {
 // TODO cblgh(2026-02-16): this route, and the methods it calls, is currently a semi-functional stub. It could do with some more work after the
 // other audit fixes are taking care of.
 func (h *Handler) HandleCloseConnection(w http.ResponseWriter, r *http.Request) {
+	log("close-connection: '%s request'", r.Method)
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -66,7 +67,6 @@ func (h *Handler) HandleCloseConnection(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-	// TODO cblgh(2026-02-16): should "close connection" ultimately also stop the https server?
 }
 
 func (h *Handler) HandlePrepare(w http.ResponseWriter, r *http.Request) {

--- a/backend/core/modules/transfer/handler.go
+++ b/backend/core/modules/transfer/handler.go
@@ -102,6 +102,9 @@ func (h *Handler) HandlePrepare(w http.ResponseWriter, r *http.Request) {
 		if errors.Is(err, transferutils.ErrTransferTooLarge) {
 			httpErrCode = http.StatusRequestEntityTooLarge
 			errMessage = "Content too large"
+		} else if errors.Is(err, transferutils.ErrTransferRejected) {
+			httpErrCode = http.StatusForbidden
+			errMessage = "Rejected"
 		} else if errors.Is(err, transferutils.ErrInvalidSession) {
 			// return 401
 			httpErrCode = http.StatusUnauthorized

--- a/backend/core/modules/transfer/service.go
+++ b/backend/core/modules/transfer/service.go
@@ -448,16 +448,12 @@ func (s *service) CloseConnection(sessionID string) error {
 	// we can use this information to differentiate in the frontend what screen we should pop back to on close-connection
 	// being fired
 	_, transferOngoing := s.transfers.Load(sessionID+"_session")
-	log("is transfer ongoing? %t", transferOngoing)
 	runtime.EventsEmit(s.ctx, "close-connection", map[string]interface{}{
 		"sessionId":        sessionID,
 		"transferOngoing":  transferOngoing,
 	})
 
-	// TODO cblgh(2026-02-16): other than forget transfer session state, what else should we do on close connection?
 	s.endTransfer(sessionID)
-
-	// TODO cblgh(2026-02-16): should "close connection" ultimately also stop the https server?
 	return nil
 }
 

--- a/backend/core/modules/transfer/service.go
+++ b/backend/core/modules/transfer/service.go
@@ -443,13 +443,15 @@ func (s *service) CloseConnection(sessionID string) error {
 	if !s.sessionIsValid(sessionID) {
 		return transferutils.ErrInvalidSession
 	}
+
+	// if we have a <sessionID>_session stored, then that means we have a transfer ongoing ->
+	// we can use this information to differentiate in the frontend what screen we should pop back to on close-connection
+	// being fired
+	_, transferOngoing := s.transfers.Load(sessionID+"_session")
+	log("is transfer ongoing? %t", transferOngoing)
 	runtime.EventsEmit(s.ctx, "close-connection", map[string]interface{}{
 		"sessionId":        sessionID,
-		"title":            "TODOTITLE", // request.Title,
-		"files":            []FileInfo{}, //request.Files,
-		"totalFiles":       0, // len(request.Files),
-		"transferredFiles": 0,
-		"totalSize":        0, // s.calculateTotalSize(request.Files),
+		"transferOngoing":  transferOngoing,
 	})
 
 	// TODO cblgh(2026-02-16): other than forget transfer session state, what else should we do on close connection?

--- a/backend/core/modules/transfer/service.go
+++ b/backend/core/modules/transfer/service.go
@@ -443,8 +443,19 @@ func (s *service) CloseConnection(sessionID string) error {
 	if !s.sessionIsValid(sessionID) {
 		return transferutils.ErrInvalidSession
 	}
+	runtime.EventsEmit(s.ctx, "close-connection", map[string]interface{}{
+		"sessionId":        sessionID,
+		"title":            "TODOTITLE", // request.Title,
+		"files":            []FileInfo{}, //request.Files,
+		"totalFiles":       0, // len(request.Files),
+		"transferredFiles": 0,
+		"totalSize":        0, // s.calculateTotalSize(request.Files),
+	})
+
 	// TODO cblgh(2026-02-16): other than forget transfer session state, what else should we do on close connection?
 	s.endTransfer(sessionID)
+
+	// TODO cblgh(2026-02-16): should "close connection" ultimately also stop the https server?
 	return nil
 }
 

--- a/backend/core/modules/transfer/service.go
+++ b/backend/core/modules/transfer/service.go
@@ -126,7 +126,7 @@ func (s *service) PrepareUpload(request *PrepareUploadRequest) (*PrepareUploadRe
 	case err := <-pendingTransfer.ErrorChan:
 		s.pendingTransfers.Delete(request.SessionID)
 		log("%v", err)
-		return nil, errPrepareUpload
+		return nil, transferutils.ErrTransferRejected
 	case <-s.done:
 		s.pendingTransfers.Delete(request.SessionID)
 		log("request timeout - connection was closed by recipient")

--- a/backend/utils/devlog/debug.go
+++ b/backend/utils/devlog/debug.go
@@ -1,6 +1,6 @@
 //go:build !production
 
 package devlog
-func isDevelop() bool {
+func IsDevelop() bool {
 	return true
 }

--- a/backend/utils/devlog/devlog.go
+++ b/backend/utils/devlog/devlog.go
@@ -5,7 +5,7 @@ import (
 )
 
 func Log(usageContext, msg string, args ...interface{}) {
-	if isDevelop() {
+	if IsDevelop() {
 		line := fmt.Sprintf(msg)
 		if len(args) > 0 {
 			line = fmt.Sprintf(msg, args...)

--- a/backend/utils/devlog/release.go
+++ b/backend/utils/devlog/release.go
@@ -1,6 +1,6 @@
 //go:build production
 
 package devlog
-func isDevelop() bool {
+func IsDevelop() bool {
 	return false
 }

--- a/frontend/src/Components/CertificateHash/CertificateHash.tsx
+++ b/frontend/src/Components/CertificateHash/CertificateHash.tsx
@@ -1,6 +1,7 @@
 // frontend/src/Components/CertificateHash/CertificateHash.tsx
 import React, { useState, useEffect } from 'react';
 import { EventsOn } from '../../../wailsjs/runtime/runtime';
+import { log } from "../../util/util"
 
 interface Props {
     serverRunning: boolean;
@@ -25,15 +26,15 @@ export function CertificateHash({ serverRunning }: Props) {
     const [certHash, setCertHash] = useState('');
 
     useEffect(() => {
-        console.log("Subscribing to certificate-hash events");
+        log("Subscribing to certificate-hash events");
 
         const cleanup = EventsOn("certificate-hash", (data) => {
-            console.log("Received certificate hash event:", data);
+            log("Received certificate hash event:", data);
             setCertHash(data.toString());
         });
 
         return () => {
-            console.log("Cleaning up certificate-hash subscription");
+            log("Cleaning up certificate-hash subscription");
             cleanup();
         };
     }, []);

--- a/frontend/src/Components/FileReceiving/FileReceiving.tsx
+++ b/frontend/src/Components/FileReceiving/FileReceiving.tsx
@@ -3,7 +3,7 @@ import { EventsOn } from '../../../wailsjs/runtime/runtime';
 import styled, { keyframes } from 'styled-components';
 import folderIcon from '../../assets/images/icons/folder-icon.svg'
 
-import { sanitizeUGC } from "../../util/util"
+import { sanitizeUGC, log } from "../../util/util"
 
 interface FileReceivingData {
   sessionId: string;
@@ -54,7 +54,7 @@ export function FileReceiving({ sessionId,
       fileSize: file.size
     }));
     setReceivingFiles(initialFiles);
-    console.log("🔄 Initialized FileReceiving with:", {
+    log("🔄 Initialized FileReceiving with:", {
       sessionId,
       transferTitle,
       totalFiles,
@@ -70,15 +70,15 @@ export function FileReceiving({ sessionId,
   //
   // i have verified that this problem is not present in release builds
   useEffect(() => {
-    console.log("Setting up FileReceiving event listeners for sessionId:", sessionId);
+    log("Setting up FileReceiving event listeners for sessionId:", sessionId);
 
     // Listen for individual file upload start events
     const cleanupReceiving = EventsOn("file-receiving", (data) => {
-      console.log("File receiving:", data);
+      log("File receiving:", data);
       const fileData = data as FileReceivingData;
       
       if (fileData.sessionId === sessionId) {
-        console.log("File receiving for our session:", fileData);
+        log("File receiving for our session:", fileData);
         setReceivingFiles(prev => {
           return prev.map(f => 
             f.fileId === fileData.fileId 
@@ -91,11 +91,11 @@ export function FileReceiving({ sessionId,
 
     // Listen for file upload completion events
     const cleanupReceived = EventsOn("file-received", (data) => {
-      console.log("✅ File received:", data);
+      log("✅ File received:", data);
       const fileData = data as FileReceivingData;
       
       if (fileData.sessionId === sessionId) {
-        console.log("✅ File completed for our session:", fileData);
+        log("✅ File completed for our session:", fileData);
         
         // Move from receiving to completed
         setReceivingFiles(prev => prev.filter(f => f.fileId !== fileData.fileId));
@@ -107,14 +107,14 @@ export function FileReceiving({ sessionId,
             if (fileData.fileSize) {
               setReceivedSize(prevSize => {
                 const newSize = prevSize + fileData.fileSize!;
-                console.log(`Updated receivedSize: ${newSize}/${totalSize}`);
+                log(`Updated receivedSize: ${newSize}/${totalSize}`);
                 return newSize;
               });
             }
 
-            console.log(`Progress: ${failedFiles.length + newCompleted.length}/${totalFiles} files completed`);
+            log(`Progress: ${failedFiles.length + newCompleted.length}/${totalFiles} files completed`);
             if ((failedFiles.length + newCompleted.length) === totalFiles && totalFiles > 0) {
-              console.log("🎉 All files completed!");
+              log("🎉 All files completed!");
               // TODO cblgh(2026-02-16): call down to the backend for a new fn "CleanupTransfer / AllFilesResolved". 
               setTimeout(() => onComplete(), 1000);
             }
@@ -127,11 +127,11 @@ export function FileReceiving({ sessionId,
 
     // Listen for file upload failure events
     const cleanupFailed = EventsOn("file-receive-failed", (data) => {
-      console.log("❌ File failed:", data);
+      log("❌ File failed:", data);
       const fileData = data as FileReceivingData;
       
       if (fileData.sessionId === sessionId) {
-        console.log("❌ File failed for our session:", fileData);
+        log("❌ File failed for our session:", fileData);
         
         // Move from receiving to failed
         setReceivingFiles(prev => prev.filter(f => f.fileId !== fileData.fileId));
@@ -141,7 +141,7 @@ export function FileReceiving({ sessionId,
             const newFailed = [...prev, fileData];
             
             if ((newFailed.length + completedFiles.length) === totalFiles && totalFiles > 0) {
-              console.log("🎉 All files completed!");
+              log("🎉 All files completed!");
               // TODO cblgh(2026-02-16): call down to the backend for a new fn "CleanupTransfer / AllFilesResolved". 
               setTimeout(() => onComplete(), 1000);
             }
@@ -154,7 +154,7 @@ export function FileReceiving({ sessionId,
 
     // Listen for file upload progress events
     const cleanupProgress = EventsOn("file-upload-progress", (data) => {
-      console.log("📈 File upload progress:", data);
+      log("📈 File upload progress:", data);
       const progressData = data as { 
         sessionId: string; 
         fileId: string; 
@@ -167,7 +167,7 @@ export function FileReceiving({ sessionId,
     // TODO cblgh(2026-02-16): event that is currently unused?
     // Listen for transfer cancellation
     const cleanupCancel = EventsOn("transfer-cancelled", (data) => {
-      console.log("❌ Transfer cancelled:", data);
+      log("❌ Transfer cancelled:", data);
       const cancelData = data as { sessionId: string };
       
       if (cancelData.sessionId === sessionId) {
@@ -178,7 +178,7 @@ export function FileReceiving({ sessionId,
     });
 
     return () => {
-      console.log("🧹 Cleaning up FileReceiving event listeners");
+      log("🧹 Cleaning up FileReceiving event listeners");
       cleanupReceiving();
       cleanupReceived();
       cleanupFailed();
@@ -198,7 +198,7 @@ export function FileReceiving({ sessionId,
   const currentFileNumber = completedFiles.length + (receivingFiles.length > 0 ? 1 : 0);
 
   const handleCancelTransfer = () => {
-    console.log("Cancel transfer requested for session:", sessionId);
+    log("Cancel transfer requested for session:", sessionId);
     // TODO cblgh(2026-02-16): bubble up call to backend for ending the transfer
     onStop();
   };

--- a/frontend/src/Components/FileRequest/FileRequest.tsx
+++ b/frontend/src/Components/FileRequest/FileRequest.tsx
@@ -6,7 +6,7 @@ import folderIcon from '../../assets/images/icons/folder-icon.svg'
 import downloadIcon from '../../assets/images/icons/download-icon.svg'
 import clockIcon from '../../assets/images/icons/clock-icon.svg'
 
-import { sanitizeUGC } from "../../util/util"
+import { sanitizeUGC, log } from "../../util/util"
 
 interface FileInfo {
   id: string;
@@ -35,12 +35,12 @@ export function FileRequest({ onAccept, onReject, onReceiving }: FileRequestProp
 
   useEffect(() => {
     const cleanupPrepareRequest = EventsOn("prepare-upload-request", (data) => {
-      console.log("Received prepare upload request:", data);
+      log("Received prepare upload request:", data);
       setRequestData(data as FileRequestData);
     });
 
     const cleanupFileReceiving = EventsOn("file-receiving", (data) => {
-      console.log("File receiving:", data);
+      log("File receiving:", data);
       onReceiving();
     });
 

--- a/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
+++ b/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
@@ -112,12 +112,20 @@ export function useNearbySharing() {
       })
     })
 
+    const cleanupCloseConnection = EventsOn("close-connection", async () => {
+      console.log("XX Received close-connection");
+      await stopServer();
+      // TODO cblgh(2026-04-29): set currentStep to something like results-error?
+      setCurrentStep('results');
+    });
+
     return () => {
       cleanupFileReceived();
       cleanupPingListener();
       cleanupRegisterListener();
       cleanupCertListener();
       cleanupPrepareRequest();
+      cleanupCloseConnection();
     };
   }, []);
 

--- a/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
+++ b/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
@@ -23,6 +23,11 @@ interface TransferData {
   totalSize: number;
 }
 
+interface CloseConnectionData {
+  sessionId: string;
+  transferOngoing: boolean;
+}
+
 export function useNearbySharing() {
   const navigate = useNavigate();
   const { isRunning: serverRunning, isStarting: isStartingServer, startServer, stopServer } = useServer();
@@ -112,11 +117,16 @@ export function useNearbySharing() {
       })
     })
 
-    const cleanupCloseConnection = EventsOn("close-connection", async () => {
-      console.log("XX Received close-connection");
+    const cleanupCloseConnection = EventsOn("close-connection", async (data) => {
+      console.log("XX Received close-connection", data);
+      const connectionData = data as CloseConnectionData;
       await stopServer();
-      // TODO cblgh(2026-04-29): set currentStep to something like results-error?
-      setCurrentStep('results');
+      if (connectionData.transferOngoing) {
+          // TODO cblgh(2026-04-29): set currentStep to something like results-error?
+          setCurrentStep('results');
+      } else {
+          setCurrentStep('intro');
+      }
     });
 
     return () => {

--- a/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
+++ b/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
@@ -188,8 +188,8 @@ export function useNearbySharing() {
   const handleFileRequestReject = () => {
     console.log("❌ File request rejected");
     setTransferData(null);
-    setCurrentSessionId('');
-    setCurrentStep('connect');
+    // go back to previous screen and allow resending
+    setCurrentStep('accept');
   };
 
   const handleFileReceiving = () => {

--- a/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
+++ b/frontend/src/Components/NearbySharing/Hooks/useNearbySharing.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { GetLocalIPs, RejectRegistration, ConfirmRegistration, StopTransfer } from "../../../../wailsjs/go/app/App";
 import { EventsOn } from "../../../../wailsjs/runtime/runtime";
 import { useServer } from "../../../Contexts/ServerContext";
+import { log } from "../../../util/util"
 
 type FlowStep = 'intro' | 'connect' | 'accept' | 'receive' | 'results';
 type ModalState = 'waiting' | 'confirm';
@@ -65,21 +66,21 @@ export function useNearbySharing() {
     fetchNetworkInfo();
 
     const cleanupPingListener = EventsOn("ping-received", (data) => {
-      console.log("Ping received from iOS device:", data);
+      log("Ping received from iOS device:", data);
       setShowVerificationModal(true);
       setModalState('waiting')
     });
 
     const cleanupRegisterListener = EventsOn("register-request-received", (data) => {
-      console.log("Register request received:", data);
-      console.log("Current QR mode:", isUsingQRModeRef.current);
+      log("Register request received:", data);
+      log("Current QR mode:", isUsingQRModeRef.current);
 
       if (isUsingQRModeRef.current) {
-        console.log("🔗 QR mode active - auto-confirming registration");
+        log("🔗 QR mode active - auto-confirming registration");
         // Auto-confirm for QR mode
         ConfirmRegistration()
           .then(() => {
-            console.log("✅ QR registration confirmed successfully");
+            log("✅ QR registration confirmed successfully");
             setCurrentStep('accept');
           })
           .catch((error) => {
@@ -89,19 +90,19 @@ export function useNearbySharing() {
             setShowVerificationModal(true);
           });
       } else {
-        console.log("📱 Manual mode - showing confirmation modal");
+        log("📱 Manual mode - showing confirmation modal");
         // Manual mode - show certificate verification modal
         setModalState('confirm');
       }
     });
 
     const cleanupCertListener = EventsOn("certificate-hash", (data) => {
-      console.log("Certificate hash received:", data);
+      log("Certificate hash received:", data);
       setCertificateHash(data.toString());
     });
 
     const cleanupPrepareRequest = EventsOn("prepare-upload-request", (data) => {
-      console.log("📨 Received prepare upload request in parent:", data);
+      log("📨 Received prepare upload request in parent:", data);
       const requestData = data as TransferData;
       setTransferData(requestData);
       setCurrentSessionId(requestData.sessionId);
@@ -118,7 +119,7 @@ export function useNearbySharing() {
     })
 
     const cleanupCloseConnection = EventsOn("close-connection", async (data) => {
-      console.log("XX Received close-connection", data);
+      log("XX Received close-connection", data);
       const connectionData = data as CloseConnectionData;
       await stopServer();
       if (connectionData.transferOngoing) {
@@ -154,7 +155,7 @@ export function useNearbySharing() {
 
   // Certificate verification handlers
   const handleVerificationConfirm = async () => {
-    console.log("✅ Certificate verification CONFIRMED");
+    log("✅ Certificate verification CONFIRMED");
     try {
       await ConfirmRegistration();
       setShowVerificationModal(false);
@@ -167,7 +168,7 @@ export function useNearbySharing() {
   };
 
   const handleVerificationDiscard = async () => {
-    console.log("❌ Certificate verification DISCARDED");
+    log("❌ Certificate verification DISCARDED");
     try {
       await RejectRegistration();
     } catch (error) {
@@ -198,25 +199,25 @@ export function useNearbySharing() {
 
   // File transfer handlers
   const handleFileRequestAccept = (sessionId: string) => {
-    console.log("📝 File request accepted for session:", sessionId);
+    log("📝 File request accepted for session:", sessionId);
     setCurrentSessionId(sessionId);
     setCurrentStep('receive');
   };
 
   const handleFileRequestReject = () => {
-    console.log("❌ File request rejected");
+    log("❌ File request rejected");
     setTransferData(null);
     // go back to previous screen and allow resending
     setCurrentStep('accept');
   };
 
   const handleFileReceiving = () => {
-    console.log("📥 File receiving started");
+    log("📥 File receiving started");
     setCurrentStep('receive');
   };
 
   const handleReceiveComplete = async () => {
-    console.log("✅ File receiving completed");
+    log("✅ File receiving completed");
     // all files have been handled (either completely transferred or failed) we can close the transfer session
     await StopTransfer(currentSessionId);
     // the file receiving is complete, stop the server
@@ -228,7 +229,7 @@ export function useNearbySharing() {
 
   // called when "stop transfer" is clicked in the middle of an ongoing transfer
   const handleStopTransfer = async () => {
-    console.log("❌ File transfer stopped");
+    log("❌ File transfer stopped");
     // stop the http server
     if (serverRunning) {
       await handleStopServer();
@@ -239,7 +240,7 @@ export function useNearbySharing() {
   }
 
   const handleViewFiles = async () => {
-    console.log("📁 View files clicked - stopping server and navigating");
+    log("📁 View files clicked - stopping server and navigating");
     if (serverRunning) {
       await handleStopServer();
     }
@@ -277,7 +278,7 @@ export function useNearbySharing() {
     handleQRModeChange: (isQR: boolean) => {
       setIsUsingQRMode(isQR);
       isUsingQRModeRef.current = isQR;
-      console.log("QR mode changed to:", isQR);
+      log("QR mode changed to:", isQR);
     },
     
     // Actions

--- a/frontend/src/Contexts/ServerContext.tsx
+++ b/frontend/src/Contexts/ServerContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, ReactNode } from 'react';
 import { StartServer, StopServer, GetDefaultPort } from '../../wailsjs/go/app/App';
+import { log } from "../util/util"
 
 interface ServerContextValue {
   isRunning: boolean;
@@ -36,9 +37,9 @@ export function ServerProvider({ children }: ServerProviderProps) {
     setServerPort(defaultPort)
     if (serverStateRef.current.isRunning || serverStateRef.current.isStarting) {
       if (serverStateRef.current.isRunning) {
-          console.log("Server is already running");
+          log("Server is already running");
       } else if (serverStateRef.current.isStarting) {
-          console.log("Server is starting up");
+          log("Server is starting up");
       }
       return serverStateRef.current.isRunning || serverStateRef.current.isStarting;
     }
@@ -71,7 +72,7 @@ export function ServerProvider({ children }: ServerProviderProps) {
 
   const stopServer = useCallback(async (): Promise<boolean> => {
     if (!serverStateRef.current.isRunning) {
-      console.log('Server not running, nothing to stop');
+      log('Server not running, nothing to stop');
       return true;
     }
 

--- a/frontend/src/util/util.ts
+++ b/frontend/src/util/util.ts
@@ -1,6 +1,14 @@
 import DOMPurify from 'dompurify';
+import { IsDevelopment } from '../../wailsjs/go/app/App';
 
 export function sanitizeUGC (userInput: string): string {
     // sanitize to only allow plain tagless strings
     return DOMPurify.sanitize(userInput, { ALLOWED_TAGS: ["#text"] })
+}
+
+export async function log(msg: string, ...rest: any[]): Promise<void> {
+    const dev = await IsDevelopment()
+    if (dev) {
+        console.log(msg, ...rest)
+    }
 }

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -27,6 +27,8 @@ export function GetServerPIN():Promise<string>;
 
 export function GetStoredFolders():Promise<Array<filestore.FolderInfo>>;
 
+export function IsDevelopment():Promise<boolean>;
+
 export function IsFirstTimeSetup():Promise<boolean>;
 
 export function IsServerRunning():Promise<boolean>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -50,6 +50,10 @@ export function GetStoredFolders() {
   return window['go']['app']['App']['GetStoredFolders']();
 }
 
+export function IsDevelopment() {
+  return window['go']['app']['App']['IsDevelopment']();
+}
+
 export function IsFirstTimeSetup() {
   return window['go']['app']['App']['IsFirstTimeSetup']();
 }


### PR DESCRIPTION
This PR adds fixes for the Asana tasks:

* 314 - _Desktop server should return a 403 Forbidden error when the user clicks Reject files_
* 310 - _Tella desktop doesn’t stop receiving files when the iOS app cancels the transfer._ 
* 313 - _After clicking Back on iOS, the desktop server continues waiting for files to be received._

These issues were deemed important as they caused inconsistent behaviour wrt the specification and proper session management.

Additionally, as I was working on these tasks I noticed that the frontend's `console.log` were still around. I added a facility for the frontend, similar to the one that exists on the backend, that only enables logging when the executing code is in development mode. The development mode is toggled on or off when building binaries - the CI process builds binaries that are tagged as `production` which turns off the dev-based logging.