### PR TITLE
Name and Certificate fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,17 +68,17 @@ jobs:
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: wails-binaries-macos
+          name: Tella Desktop macOS
           path: build/bin/*
       - name: upload artifacts windows
         if: matrix.platform == 'ubuntu-24.04'
         uses: actions/upload-artifact@v4
         with:
-          name: wails-binaries-windows
+          name: Tella Desktop Windows
           path: build/bin/*
       - name: upload artifacts linux
         if: matrix.platform == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: wails-binaries-linux
+          name: Tella Desktop Linux
           path: build/bin/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH"
           security default-keychain -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
       - name: Build OSX 
         if: matrix.platform == 'macos-latest'
         # Tella-Desktop.app is a folder, while tella.app is the executable inside that folder -- confusing? Yes, unfortunately!
@@ -72,6 +73,7 @@ jobs:
           echo "Removing old .app"
           rm -rf "Tella-Desktop.app" 
           wails build --platform "darwin/universal" --ldflags="-s -w"
+          codesign --force --deep --options runtime --timestamp --entitlements ./build/darwin/entitlements.plist --sign "Developer ID Application: Horizontal (6ZG9T42688)" ./build/bin/Tella-Desktop.app
           codesign --verify --deep --strict --verbose=2 ./build/bin/Tella-Desktop.app
           appdmg ./dmg.json ./build/bin/tella.dmg
       - name: Notarize and staple macOS DMG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
         platform: [macos-latest, ubuntu-24.04, ubuntu-latest]
         go-version: [1.24.1]
     runs-on: ${{ matrix.platform }}
+    env:
+      APPLE_TEAM_ID: 6ZG9T42688
+      MACOS_CODESIGN_NAME: Horizontal
     steps:
       - uses: actions/checkout@v4
       - name: Install Go
@@ -73,7 +76,7 @@ jobs:
           echo "Removing old .app"
           rm -rf "Tella-Desktop.app" 
           wails build --platform "darwin/universal" --ldflags="-s -w"
-          codesign --force --deep --options runtime --timestamp --entitlements ./build/darwin/entitlements.plist --sign "Developer ID Application: Horizontal (6ZG9T42688)" ./build/bin/Tella-Desktop.app
+          codesign --force --deep --options runtime --timestamp --entitlements ./build/darwin/entitlements.plist --sign "Developer ID Application: ${MACOS_CODESIGN_NAME} (${APPLE_TEAM_ID})" ./build/bin/Tella-Desktop.app
           codesign --verify --deep --strict --verbose=2 ./build/bin/Tella-Desktop.app
           appdmg ./dmg.json ./build/bin/tella.dmg
       - name: Notarize and staple macOS DMG
@@ -81,7 +84,6 @@ jobs:
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          APPLE_TEAM_ID: 6ZG9T42688
         run: |
           xcrun notarytool submit ./build/bin/tella.dmg \
             --apple-id "$APPLE_ID" \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,15 +47,47 @@ jobs:
         run: |
           npm install -g appdmg
           echo ' { "title": "Tella", "icon": "./defaultappicon.icns", "contents": [ { "x": 448, "y": 344, "type": "link", "path": "/Applications" }, { "x": 192, "y": 344, "type": "file", "path": "./build/bin/Tella-Desktop.app" } ] } ' > dmg.json
+      - name: Import macOS signing certificate
+        if: matrix.platform == 'macos-latest'
+        env:
+          MACOS_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          CERTIFICATE_PATH="$RUNNER_TEMP/macos-signing-certificate.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+
+          printf "%s" "$MACOS_CERTIFICATE_BASE64" | base64 -D > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
       - name: Build OSX 
         if: matrix.platform == 'macos-latest'
-        # TODO: get OSX signing working
         # Tella-Desktop.app is a folder, while tella.app is the executable inside that folder -- confusing? Yes, unfortunately!
         run: |
           echo "Removing old .app"
           rm -rf "Tella-Desktop.app" 
           wails build --platform "darwin/universal" --ldflags="-s -w"
+          codesign --verify --deep --strict --verbose=2 ./build/bin/Tella-Desktop.app
           appdmg ./dmg.json ./build/bin/tella.dmg
+      - name: Notarize and staple macOS DMG
+        if: matrix.platform == 'macos-latest'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: 6ZG9T42688
+        run: |
+          xcrun notarytool submit ./build/bin/tella.dmg \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+          xcrun stapler staple ./build/bin/tella.dmg
+          xcrun stapler validate ./build/bin/tella.dmg
       - name: Build for Windows (on linux!)
         if: matrix.platform == 'ubuntu-24.04'
         run: |

--- a/README.md
+++ b/README.md
@@ -143,17 +143,21 @@ The application implements the [Tella Nearby Sharing protocol](https://github.co
 
 ### macOS Code Signing
 
-The application is configured for code signing on macOS for distribution outside the App Store:
+The application is configured for code signing and notarization on macOS for distribution outside the App Store:
 
 - Uses Developer ID Application certificate for notarization
 - Includes hardened runtime options for security
 - Requires valid Apple Developer account for signing
 
-To build a signed version for macOS:
+The GitHub Actions macOS build expects these repository secrets:
 
-- Update the identity in wails.json with your Developer ID
-- Ensure you have a valid Developer ID Application certificate
-- Run wails build - the app will be automatically signed during build
+- `MACOS_CERTIFICATE_BASE64` - Base64 encoded `.p12` certificate
+- `MACOS_CERTIFICATE_PASSWORD` - Password for the `.p12` certificate
+- `KEYCHAIN_PASSWORD` - Temporary CI keychain password
+- `APPLE_ID` - Apple ID email with access to the developer team
+- `APPLE_APP_SPECIFIC_PASSWORD` - App-specific password for notarization
+
+The certificate identity is configured in `wails.json` as `Developer ID Application: Horizontal (6ZG9T42688)`.
 
 ### Compatibility
 

--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -8,7 +8,7 @@
         <key>CFBundleExecutable</key>
         <string>{{.Name}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{.Name}}</string>
+        <string>org.wearehorizontal.tella-desktop.dev</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -8,7 +8,7 @@
         <key>CFBundleExecutable</key>
         <string>{{.Name}}</string>
         <key>CFBundleIdentifier</key>
-        <string>com.wails.{{.Name}}</string>
+        <string>org.wearehorizontal.tella-desktop</string>
         <key>CFBundleVersion</key>
         <string>{{.Info.ProductVersion}}</string>
         <key>CFBundleGetInfoString</key>

--- a/wails.json
+++ b/wails.json
@@ -20,7 +20,7 @@
   "darwin": {
     "sign": true,
     "codesign": {
-      "identity": "Developer ID Application: YOUR_ORG_NAME (YOUR_TEAM_ID)",
+      "identity": "Developer ID Application: Horizontal (6ZG9T42688)",
       "entitlements": "build/darwin/entitlements.plist",
       "options": [
         "--timestamp",

--- a/wails.json
+++ b/wails.json
@@ -7,8 +7,8 @@
   "frontend:dev:watcher": "npm run dev",
   "frontend:dev:serverUrl": "auto",
   "author": {
-    "name": "valbuenag",
-    "email": "valbuena52@gmail.com"
+    "name": "Horizontal",
+    "email": "dev@wearehorizontal.org"
   },
   "buildTags": "sqlite_unlock_notify sqlite_crypt sqlcipher",
   "info": {


### PR DESCRIPTION
Prepares Tella Desktop for Horizontal-branded macOS distribution: correct bundle ID and author metadata, Developer ID signing + notarization in CI, and clearer release artifact names. 
